### PR TITLE
Remove reference to AllowFreeze

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -13,7 +13,6 @@ func init() {
 	resolve.AllowNestedDef = true // allow def statements within function bodies
 	resolve.AllowLambda = true    // allow lambda expressions
 	resolve.AllowFloat = true     // allow floating point literals, the 'float' built-in, and x / y
-	resolve.AllowFreeze = true    // allow the 'freeze' built-in
 	resolve.AllowSet = true       // allow the 'set' built-in
 }
 


### PR DESCRIPTION
The `resolve.AllowFreeze` package var disappeared a few weeks ago upstream in commit ffb61b871f41afe93fdd2ab826a4f352cb770a83.|

(Tangentially, I'm not a big fan of side-effecting imports like this, and would vote for dropping that whole init func.  But that's another matter; this just fixes things to build again.)